### PR TITLE
First implementation of unfold primitive.

### DIFF
--- a/dsbox/datapostprocessing/__init__.py
+++ b/dsbox/datapostprocessing/__init__.py
@@ -1,7 +1,11 @@
 from .vertical_concat import VerticalConcat, VerticalConcatHyperparams
+from .ensemble_voting import EnsembleVoting, EnsembleVotingHyperparams
+from .unfold import Unfold, UnfoldHyperparams
 
 __all__ = [
-    'VerticalConcat', 'VerticalConcatHyperparams'
+    'VerticalConcat', 'VerticalConcatHyperparams',
+    'EnsembleVoting', 'EnsembleVotingHyperparams',
+    'Unfold', 'UnfoldHyperparams'
 ]
 
 from pkgutil import extend_path

--- a/dsbox/datapostprocessing/ensemble_voting.py
+++ b/dsbox/datapostprocessing/ensemble_voting.py
@@ -1,6 +1,6 @@
-from d3m import container, types
+from d3m import container
 from d3m.primitive_interfaces.transformer import TransformerPrimitiveBase
-from d3m.metadata import hyperparams, params, base as metadata_base
+from d3m.metadata import hyperparams
 from dsbox.datapreprocessing.cleaner import config
 from d3m.primitive_interfaces.base import CallResult
 import common_primitives.utils as common_utils
@@ -51,7 +51,7 @@ class EnsembleVoting(TransformerPrimitiveBase[Inputs, Outputs, EnsembleVotingHyp
             metadata=inputs.metadata, semantic_types=["https://metadata.datadrivendiscovery.org/types/PrimaryKey"])
         predict_target_col = common_utils.list_columns_with_semantic_types(
             metadata=inputs.metadata, semantic_types=["https://metadata.datadrivendiscovery.org/types/PredictedTarget"])
-        new_df = self._get_index_and_target_df(inputs=df, use_cols=index_col+predict_target_col)
+        new_df = self._get_index_and_target_df(inputs=df, use_cols=index_col + predict_target_col)
 
         if self.hyperparams["ensemble_method"] == 'majority':
             groupby_df = new_df.groupby([new_df.columns[pos] for pos in index_col]).agg(

--- a/dsbox/datapostprocessing/unfold.py
+++ b/dsbox/datapostprocessing/unfold.py
@@ -16,7 +16,7 @@ Outputs = container.DataFrame
 class UnfoldHyperparams(hyperparams.Hyperparams):
     unfold_semantic_types = hyperparams.Set(
         elements=hyperparams.Hyperparameter[str]("str"),
-        default=["https://metadata.datadrivendiscovery.org/types/SuggestedTarget", "http://schema.org/Float"],
+        default=["https://metadata.datadrivendiscovery.org/types/PredictedTarget"],
         semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter'],
         description=
         """

--- a/dsbox/datapostprocessing/unfold.py
+++ b/dsbox/datapostprocessing/unfold.py
@@ -1,0 +1,200 @@
+from d3m import container
+from d3m.primitive_interfaces.transformer import TransformerPrimitiveBase
+from d3m.metadata import hyperparams
+from dsbox.datapreprocessing.cleaner import config
+from d3m.primitive_interfaces.base import CallResult
+import common_primitives.utils as common_utils
+import d3m.metadata.base as mbase
+import warnings
+
+
+__all__ = ('Unfold',)
+
+Inputs = container.DataFrame
+Outputs = container.DataFrame
+
+
+class UnfoldHyperparams(hyperparams.Hyperparams):
+    unfold_semantic_types = hyperparams.Set(
+        elements=hyperparams.Hyperparameter[str]("str"),
+        default=["https://metadata.datadrivendiscovery.org/types/SuggestedTarget", "http://schema.org/Float"],
+        semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter'],
+        description=
+        """
+        A set of semantic types that the primitive will unfold.
+        Only 'https://metadata.datadrivendiscovery.org/types/PredictedTarget' by default.
+        """,
+    )
+    use_pipeline_id_semantic_type = hyperparams.UniformBool(
+        default=False,
+        semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter'],
+        description=
+        """
+        Controls whether semantic_type will be used for finding pipeline id column in input dataframe.
+        If true, it will look for 'https://metadata.datadrivendiscovery.org/types/PipelineId' for pipeline id column,
+        and create attribute columns using header: attribute_{pipeline_id}. 
+        eg. 'binaryClass_{a3180751-33aa-4790-9e70-c79672ce1278}'
+        If false, create attribute columns using header: attribute_{0,1,2,...}.
+        eg. 'binaryClass_0', 'binaryClass_1'
+        """,
+    )
+
+
+class Unfold(TransformerPrimitiveBase[Inputs, Outputs, UnfoldHyperparams]):
+    """
+        A primitive which concat a list of dataframe to a single dataframe vertically
+    """
+
+    __author__ = 'USC ISI'
+    metadata = hyperparams.base.PrimitiveMetadata({
+        "id": "dsbox-unfold",
+        "version": config.VERSION,
+        "name": "DSBox unfold",
+        "description": "A primitive which unfold a vertically concatenated dataframe",
+        "python_path": "d3m.primitives.dsbox.Unfold",
+        "primitive_family": "DATA_CLEANING",
+        "algorithm_types": ["DATA_CONVERSION"],
+        "source": {
+            "name": config.D3M_PERFORMER_TEAM,
+            "uris": [config.REPOSITORY]
+        },
+        "keywords": ["unfold"],
+        "installation": [config.INSTALLATION],
+    })
+
+    def __init__(self, *, hyperparams: UnfoldHyperparams) -> None:
+        super().__init__(hyperparams=hyperparams)
+        self.hyperparams = hyperparams
+        self._sorted_pipe_ids = None
+
+    def produce(self, *, inputs: Inputs, timeout: float = None, iterations: int = None) -> CallResult[Outputs]:
+        primary_key_cols = common_utils.list_columns_with_semantic_types(
+            metadata=inputs.metadata,
+            semantic_types=["https://metadata.datadrivendiscovery.org/types/PrimaryKey"]
+        )
+
+        unfold_cols = common_utils.list_columns_with_semantic_types(
+            metadata=inputs.metadata,
+            semantic_types=self.hyperparams["unfold_semantic_types"]
+        )
+
+        if not primary_key_cols:
+            warnings.warn("Did not find primary key column for grouping. Will not unfold")
+            return CallResult(inputs)
+
+        if not unfold_cols:
+            warnings.warn("Did not find any column to unfold. Will not unfold")
+            return CallResult(inputs)
+
+        primary_key_col_names = [inputs.columns[pos] for pos in primary_key_cols]
+        unfold_col_names = [inputs.columns[pos] for pos in unfold_cols]
+
+        if self.hyperparams["use_pipeline_id_semantic_type"]:
+            pipeline_id_cols = common_utils.list_columns_with_semantic_types(
+                metadata=inputs.metadata,
+                semantic_types=["https://metadata.datadrivendiscovery.org/types/PipelineId"]
+            )
+
+            if len(pipeline_id_cols) >= 2:
+                warnings.warn("Multiple pipeline id columns found. Will use first.")
+
+            if pipeline_id_cols:
+                inputs = inputs.sort_values(primary_key_col_names+[inputs.columns[pos] for pos in pipeline_id_cols])
+                self._sorted_pipe_ids = sorted(inputs.iloc[:, pipeline_id_cols[0]].unique())
+            else:
+                warnings.warn(
+                    "No pipeline id column found by 'https://metadata.datadrivendiscovery.org/types/PipelineId'")
+
+        new_df = self._get_new_df(inputs=inputs, use_cols=primary_key_cols+unfold_cols)
+
+        groupby_df = inputs.groupby(primary_key_col_names)[unfold_col_names].aggregate(
+            lambda x: container.List(x)).reset_index(drop=False)
+
+        ret_df = container.DataFrame(groupby_df)
+        ret_df.metadata = new_df.metadata
+        ret_df = self._update_metadata(df=ret_df)
+
+        split_col_names = [inputs.columns[pos] for pos in unfold_cols]
+
+        ret_df = self._split_aggregated(df=ret_df, split_col_names=split_col_names)
+        ret_df = common_utils.remove_columns(
+            inputs=ret_df,
+            column_indices=[ret_df.columns.get_loc(name) for name in split_col_names]
+        )
+
+        return CallResult(ret_df)
+
+    @staticmethod
+    def _get_new_df(inputs: container.DataFrame, use_cols):
+        metadata = common_utils.select_columns_metadata(inputs_metadata=inputs.metadata, columns=use_cols)
+        new_df = inputs.iloc[:, use_cols]
+        new_df.metadata = metadata
+        return new_df
+
+    @staticmethod
+    def _update_metadata(df: container.DataFrame) -> container.DataFrame:
+        old_metadata = dict(df.metadata.query(()))
+        old_metadata["dimension"] = dict(old_metadata["dimension"])
+        old_metadata["dimension"]["length"] = df.shape[0]
+        df.metadata = df.metadata.update((), old_metadata)
+        return df
+
+    def _split_aggregated(self, df, split_col_names):
+        lengths = [len(df.loc[0, col_name]) for col_name in split_col_names]
+
+        for idx, col_name in enumerate(split_col_names):
+            if self._sorted_pipe_ids:
+                if len(self._sorted_pipe_ids) == lengths[idx]:
+                    extend_col_names = ["{}_{}".format(col_name, i) for i in self._sorted_pipe_ids]
+                else:
+                    raise ValueError("Unique number of pipeline ids not equal to the number of aggregated values")
+            else:
+                extend_col_names = ["{}_{}".format(col_name, i) for i in range(lengths[idx])]
+
+            extends = container.DataFrame(df.loc[:, col_name].values.tolist(), columns=extend_col_names)
+
+            df = common_utils.horizontal_concat(left=df, right=extends)
+            origin_metadata = dict(df.metadata.query((mbase.ALL_ELEMENTS, df.columns.get_loc(col_name))))
+
+            for name in extend_col_names:
+                col_idx = df.columns.get_loc(name)
+                origin_metadata["name"] = name
+                df.metadata = df.metadata.update((mbase.ALL_ELEMENTS, col_idx), origin_metadata)
+
+        return df
+
+
+if __name__ == '__main__':
+    import os
+    from d3m.container.dataset import D3MDatasetLoader
+    from dsbox.datapreprocessing.cleaner.denormalize import Denormalize, DenormalizeHyperparams as hyper_DE
+    from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive, Hyperparams as hyper_DD
+    from dsbox.datapostprocessing.vertical_concat import VerticalConcatHyperparams, VerticalConcat
+
+    h_de = hyper_DE.defaults()
+    h_dd = hyper_DD.defaults()
+    h_e_a = {'semantic_types': ('https://metadata.datadrivendiscovery.org/types/Attribute',),
+             'use_columns': (),
+             'exclude_columns': ()}
+    h_e_t = {'semantic_types': ('https://metadata.datadrivendiscovery.org/types/Target',
+                                'https://metadata.datadrivendiscovery.org/types/SuggestedTarget',),
+             'use_columns': (),
+             'exclude_columns': ()}
+
+    primitive_0 = Denormalize(hyperparams=h_de)
+    primitive_1 = DatasetToDataFramePrimitive(hyperparams=h_dd)
+
+    dataset_file_path = '/Users/runqishao/Downloads/datasets_dsbox/training_datasets/LL0/LL0_1026_grub_damage/LL0_1026_grub_damage_dataset/datasetDoc.json'
+    dataset = D3MDatasetLoader()
+    dataset = dataset.load(
+        'file://{dataset_doc_path}'.format(dataset_doc_path=os.path.abspath(dataset_file_path)))
+
+    result0 = primitive_0.produce(inputs=dataset)
+    result1 = primitive_1.produce(inputs=result0.value)  # this should be the input to this primitive
+
+    p = VerticalConcat(hyperparams=VerticalConcatHyperparams.defaults())
+    result = p.produce(inputs=container.List([result1.value, result1.value, result1.value]))
+    pp = Unfold(hyperparams=UnfoldHyperparams.defaults())
+    rr = pp.produce(inputs=result.value)
+    import pdb
+    pdb.set_trace()

--- a/dsbox/datapostprocessing/unfold.py
+++ b/dsbox/datapostprocessing/unfold.py
@@ -111,7 +111,7 @@ class Unfold(TransformerPrimitiveBase[Inputs, Outputs, UnfoldHyperparams]):
 
         ret_df = container.DataFrame(groupby_df)
         ret_df.metadata = new_df.metadata
-        ret_df = self._update_metadata(df=ret_df)
+        ret_df = self._update_metadata_dimension(df=ret_df)
 
         split_col_names = [inputs.columns[pos] for pos in unfold_cols]
 
@@ -124,21 +124,21 @@ class Unfold(TransformerPrimitiveBase[Inputs, Outputs, UnfoldHyperparams]):
         return CallResult(ret_df)
 
     @staticmethod
-    def _get_new_df(inputs: container.DataFrame, use_cols):
+    def _get_new_df(inputs: container.DataFrame, use_cols: list):
         metadata = common_utils.select_columns_metadata(inputs_metadata=inputs.metadata, columns=use_cols)
         new_df = inputs.iloc[:, use_cols]
         new_df.metadata = metadata
         return new_df
 
     @staticmethod
-    def _update_metadata(df: container.DataFrame) -> container.DataFrame:
+    def _update_metadata_dimension(df: container.DataFrame) -> container.DataFrame:
         old_metadata = dict(df.metadata.query(()))
         old_metadata["dimension"] = dict(old_metadata["dimension"])
         old_metadata["dimension"]["length"] = df.shape[0]
         df.metadata = df.metadata.update((), old_metadata)
         return df
 
-    def _split_aggregated(self, df, split_col_names):
+    def _split_aggregated(self, df: container.DataFrame, split_col_names: list) -> container.DataFrame:
         lengths = [len(df.loc[0, col_name]) for col_name in split_col_names]
 
         for idx, col_name in enumerate(split_col_names):

--- a/dsbox/datapostprocessing/vertical_concat.py
+++ b/dsbox/datapostprocessing/vertical_concat.py
@@ -5,6 +5,7 @@ from dsbox.datapreprocessing.cleaner import config
 from d3m.primitive_interfaces.base import CallResult
 import common_primitives.utils as common_utils
 import pandas as pd
+import warnings
 
 __all__ = ('VerticalConcat',)
 
@@ -58,6 +59,9 @@ class VerticalConcat(TransformerPrimitiveBase[Inputs, Outputs, VerticalConcatHyp
         if self.hyperparams["sort_on_primary_key"]:
             primary_key_col = common_utils.list_columns_with_semantic_types(metadata=new_df.metadata, semantic_types=[
                 "https://metadata.datadrivendiscovery.org/types/PrimaryKey"])
+            if not primary_key_col:
+                warnings.warn("No PrimaryKey column found. Will not sort on PrimaryKey")
+                return CallResult(self._update_metadata(new_df))
             new_df = new_df.sort_values([new_df.columns[pos] for pos in primary_key_col])
         return CallResult(self._update_metadata(new_df))
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(name='dsbox-datacleaning',
               'dsbox.FoldColumns = dsbox.datapreprocessing.cleaner:FoldColumns',
               'dsbox.Voter = dsbox.datapreprocessing.cleaner:Voter',
               'dsbox.VerticalConcat = dsbox.datapostprocessing:VerticalConcat',
-              'dsbox.EnsembleVoting = dsbox.datapostprocessing:EnsembleVoting'
+              'dsbox.EnsembleVoting = dsbox.datapostprocessing:EnsembleVoting',
+              'dsbox.Unfold = dsbox.datapostprocessing:Unfold'
           ],
       }
       )


### PR DESCRIPTION
First version implementation of `unfold`. #56 

This primitive unfolds a vertically concatenated dataframe.

1. All indices will have prediction results for all pipelines. So if group by `d3mIndex`, each single index will have same number of `PredictedTarget` for all pipeline ids. Only `https://metadata.datadrivendiscovery.org/types/PredictedTarget` by default.

2. `unfold_semantic_types` hyperparam is a set of semantic types that the primitive will unfold.  Primitive will look for columns contains those semantic_types and unfold those columns

3. `use_pipeline_id_semantic_type` hyperparam is a boolean controlling whether semantic_type will be used for finding pipeline id column in input dataframe. 
If true, it will look for `https://metadata.datadrivendiscovery.org/types/PipelineId` for pipeline id column, and create attribute columns using header: attribute_{pipeline_id}. eg. `binaryClass_{a3180751-33aa-4790-9e70-c79672ce1278}`. 
If false, create attribute columns using header: attribute_{0,1,2,...}. eg. `binaryClass_0`, `binaryClass_1`
If there are multiple columns have semantic_type `https://metadata.datadrivendiscovery.org/types/PipelineId`, always use the first one
Default `False`
Note: May need to ask for adding `https://metadata.datadrivendiscovery.org/types/PipelineId` as new d3m semantic_type

4. Primitive will look for `PrimaryKey` for grouping. 

5. If no `PrimaryKey`, or no columns to unfold, return original df.

6. Columns in result df will have same metadata as the metadata in input df. Eg. `binaryClass_0` column will have same metadata as `binaryClass` column in original df. Only different is the column name